### PR TITLE
Updated import-emails command to use argparse and fixed exception syntax

### DIFF
--- a/manager/management/commands/import-emails.py
+++ b/manager/management/commands/import-emails.py
@@ -1,57 +1,51 @@
 from django.core.management.base import BaseCommand, CommandError
-from optparse                    import make_option
-from util                        import LDAPHelper 
+from util                        import LDAPHelper
 from django.conf                 import settings
 from manager.models               import Recipient, RecipientAttribute, RecipientGroup
 from manager.utils               import CSVImport
 import csv
 
 class Command(BaseCommand):
-	option_list = BaseCommand.option_list + (
-		make_option(
-			'--group-name',
-			action  ='store',
-			dest    ='group_name',
-			default ='',
-		),
-		make_option(
-			'--column-order',
-			action  ='store',
-			dest    ='column_order',
-			default ='first_name,last_name,email,preferred_name'
-		),
-		make_option(
-			'--ignore-first-row',
-			action  ='store_true',
-			dest    ='ignore_first_row',
-			default = False
+
+	def add_arguments(self, parser):
+		parser.add_argument(
+			'csv',
+			type=str,
+			help='The csv file to import.'
 		)
-	)
-	def handle(self, *args, **kwargs):
 
-		if len(args) == 0 or len(args) > 1:
-			print 'Usage: python manage.py import-emails [filename] [options]'
-			print 'Options:'
-			print '--group-name [group name]'
-			print '\tWill add recipients to the specified recipient group.'
-			print '\tThe group will be created if it does not exist.'
-			print '\tIf not specified, recipients will not be added to any group.'
-			print '--column-order [columns]'
-			print '\tDefault: first_name,last_name,email,preferred_name'
-			print '\tThe column order of the CSV. The first_name, last_name, and email'
-			print '\tcolumn names must be present.'
-			print '--ignore-first-row'
-			print '\tIgnore the first row of the CSV. Useful if there are column'
-			print '\theaders present.'
-		else:
-			filename            = args[0]
-			group_name          = kwargs.get('group_name')
-			columns             = list(col.strip() for col in kwargs.get('column_order').split(','))
-			ignore_first_row = kwargs.get('ignore_first_row')
+		parser.add_argument(
+			'--group-name',
+			dest='group_name',
+			type=str,
+			help='The name of the new or existing group to import the emails to.',
+			default=''
+		)
 
-			importer = CSVImport(open(filename, 'rU'), group_name, ignore_first_row, columns)
-			try:
-				importer.import_emails()
-			except Exception, e:
-				print "Error importing recipients: %s" % str(e)
-				
+		parser.add_argument(
+			'--column-order',
+			dest='columns',
+			type=str,
+			help='The order of the columns in the csv.',
+			default='first_name,last_name,email,preferred_name'
+		)
+
+		parser.add_argument(
+			'--ignore-first-row',
+			dest='ignore_first_row',
+			type=bool,
+			help='If True, the first row will be skipped.',
+			default=False
+		)
+
+	def handle(self, *args, **options):
+		filename = options['csv']
+		group_name = options['group_name']
+		columns = list(col.strip() for col in options['columns'].split(','))
+		ignore_first_row = options['ignore_first_row']
+
+		importer = CSVImport(open(filename, 'rU'), group_name, ignore_first_row, columns)
+		try:
+			importer.import_emails()
+		except Exception, e:
+			print "Error importing recipients: %s" % str(e)

--- a/manager/management/commands/recipient-importers.py
+++ b/manager/management/commands/recipient-importers.py
@@ -1,4 +1,4 @@
-from django.core.management.base import BaseCommand, CommandErrormake_option
+from django.core.management.base import BaseCommand, CommandError
 from manager.models              import Recipient, RecipientGroup
 from django.conf                 import settings
 from django.db                   import connections, transaction

--- a/manager/management/commands/recipient-importers.py
+++ b/manager/management/commands/recipient-importers.py
@@ -1,5 +1,4 @@
-from django.core.management.base import BaseCommand, CommandError
-from optparse                    import make_option
+from django.core.management.base import BaseCommand, CommandErrormake_option
 from manager.models              import Recipient, RecipientGroup
 from django.conf                 import settings
 from django.db                   import connections, transaction

--- a/manager/utils.py
+++ b/manager/utils.py
@@ -145,7 +145,7 @@ class CSVImport:
 
                             try:
                                 attribute_first_name.save()
-                            except Exeception, e:
+                            except Exception, e:
                                 print 'Error saving recipient attibute First Name at line %d, %s' % (row_num, str(e))
 
                         if last_name is not None:


### PR DESCRIPTION
Bug Fixes:
* Updated command line email importer to use `argparse` which is what Django 1.10+ uses instead of `optparse`.
* Fixed an exception statement which was incorrect (misspelled).