### PR TITLE
Paging fix

### DIFF
--- a/manager/forms.py
+++ b/manager/forms.py
@@ -167,7 +167,7 @@ RecipientAttributeFormSet = inlineformset_factory(Recipient, RecipientAttribute,
 
 
 class RecipientSearchForm(forms.Form):
-    email_address = forms.CharField(widget=forms.TextInput())
+    search_query = forms.CharField(widget=forms.TextInput())
 
 
 class RecipientSubscriptionsForm(forms.ModelForm):

--- a/manager/views.py
+++ b/manager/views.py
@@ -118,6 +118,20 @@ class SortSearchMixin(object):
         context['sort'] = self._sort
         context['order'] = self._order
         context['search_query'] = self._search_query
+
+        if 'page_obj' in context:
+            page = context['page_obj']
+
+        if page in context and page.has_previous():
+            url = '?page=' + str(page.previous_page_number())
+            url += '&search_query=' + self._search_query if self._search_query != '' else ''
+            context['previous_url'] = url
+
+        if page and page.has_next():
+            url = '?page=' + str(page.next_page_number())
+            url += '&search_query=' + self._search_query if self._search_query != '' else ''
+            context['next_url'] = url
+
         return context
 
 class EmailsMixin(object):

--- a/manager/views.py
+++ b/manager/views.py
@@ -77,7 +77,7 @@ log = logging.getLogger(__name__)
 ##
 class SortSearchMixin(object):
     def get_queryset(self):
-        queryset = super(SortSearchMixin, self).get_queryset();
+        queryset = super(SortSearchMixin, self).get_queryset()
 
         # sort parameter
         self._sort = 'asc'
@@ -122,7 +122,7 @@ class SortSearchMixin(object):
         if 'page_obj' in context:
             page = context['page_obj']
 
-        if page in context and page.has_previous():
+        if page and page.has_previous():
             url = '?page=' + str(page.previous_page_number())
             url += '&search_query=' + self._search_query if self._search_query != '' else ''
             context['previous_url'] = url
@@ -625,17 +625,21 @@ class RecipientGroupDeleteView(RecipientGroupsMixin, DeleteView):
 ##
 # Recipients
 ##
-class RecipientListView(RecipientsMixin, ListView):
+class RecipientListView(RecipientsMixin, SortSearchMixin, ListView):
     model = Recipient
     template_name = 'manager/recipients.html'
     context_object_name = 'recipients'
     paginate_by = 20
 
     def get_queryset(self):
+        self.search_field = 'email_address'
+        self.search_form = EmailSearchForm(self.request.GET)
+        super(RecipientListView, self).get_queryset()
+
         self._search_form = RecipientSearchForm(self.request.GET)
         self._search_valid = self._search_form.is_valid()
         if self._search_valid:
-            return Recipient.objects.filter(email_address__icontains=self._search_form.cleaned_data['email_address'])
+            return Recipient.objects.filter(email_address__icontains=self._search_form.cleaned_data['search_query'])
         else:
             return Recipient.objects.all().order_by('disable', 'email_address')
 
@@ -643,7 +647,7 @@ class RecipientListView(RecipientsMixin, ListView):
         context = super(RecipientListView, self).get_context_data(**kwargs)
         context['search_form'] = self._search_form
         context['search_valid'] = self._search_valid
-        context['search_query'] = self._search_form.cleaned_data['email_address'] if self._search_valid else ''
+        context['search_query'] = self._search_form.cleaned_data['search_query'] if self._search_valid else ''
         return context
 
 

--- a/templates/manager/emails.html
+++ b/templates/manager/emails.html
@@ -30,7 +30,7 @@
       <ul class="pagination pagination-sm">
         {% if page_obj.has_previous %}
         <li class="page-item">
-          <a class="page-link" href="?page={{page_obj.previous_page_number}}">
+          <a class="page-link" href="{{ previous_url }}">
             <span class="fas fa-chevron-left" aria-hidden="true"></span> Previous
           </a>
         </li>
@@ -40,7 +40,7 @@
         </li>
         {% if page_obj.has_next %}
         <li class="page-item">
-          <a class="page-link" href="?page={{page_obj.next_page_number}}" class="next">
+          <a class="page-link" href="{{ next_url }}" class="next">
             Next <span class="fas fa-chevron-right" aria-hidden="true"></span>
           </a>
         </li>

--- a/templates/manager/emails.html
+++ b/templates/manager/emails.html
@@ -86,7 +86,7 @@
     <ul class="pagination pagination-sm">
       {% if page_obj.has_previous %}
       <li class="page-item">
-        <a class="page-link" href="?page={{page_obj.previous_page_number}}">
+        <a class="page-link" href="{{ previous_url }}">
           <span class="fas fa-chevron-left" aria-hidden="true"></span> Previous
         </a>
       </li>
@@ -96,7 +96,7 @@
       </li>
       {% if page_obj.has_next %}
       <li class="page-item">
-        <a class="page-link" href="?page={{page_obj.next_page_number}}" class="next">
+        <a class="page-link" href="{{ next_url }}" class="next">
           Next
           <span class="fas fa-chevron-right" aria-hidden="true"></span>
         </a>

--- a/templates/manager/recipientgroups.html
+++ b/templates/manager/recipientgroups.html
@@ -16,7 +16,7 @@
           Showing {{ page_obj.paginator.count }} search result{% if page_obj.paginator.count > 1 %}s{% endif %} for <span class="text-complementary font-weight-bold">&ldquo;{{ search_query }}&rdquo;</span>
         </p>
       {% endif %}
-      <form class="form-inline float-right" action="{% url 'manager-recipientgroups' %}" method="get">
+      <form class="form-inline float-right" action="{% if preview %}{% url 'manager-recipientgroups-previewgroups' %}{% else %}{% url 'manager-recipientgroups-previewgroups' %}{% endif %}" method="get">
         <div class="form-group">
           <div class="input-group">
             {{search_form.search_query|add_class:"form-control form-control-sm search-query"|attr:"required"|attr:"placeholder:Search for..."|attr:"aria-label:Search for..."}}

--- a/templates/manager/recipients.html
+++ b/templates/manager/recipients.html
@@ -16,7 +16,7 @@
       <form class="form-inline float-right" action="{% url 'manager-recipients' %}" method="get">
         <div class="form-group">
           <div class="input-group">
-            {{search_form.email_address|add_class:"form-control form-control-sm search-query"|attr:"required"|attr:"placeholder:Search for..."|attr:"aria-label:Search for..."}}
+            {{search_form.search_query|add_class:"form-control form-control-sm search-query"|attr:"required"|attr:"placeholder:Search for..."|attr:"aria-label:Search for..."}}
             <span class="input-group-btn">
               <button class="btn btn-primary btn-sm" type="submit"><span class="fas fa-search" aria-hidden="true"></span><span class="sr-only">Search</span></button>
             </span>
@@ -33,7 +33,7 @@
           <ul class="pagination pagination-sm">
             {% if page_obj.has_previous %}
             <li class="page-item">
-              <a class="page-link" href="?page={{page_obj.previous_page_number}}">
+              <a class="page-link" href="{{ previous_url }}">
                 <span class="fas fa-chevron-left" aria-hidden="true"></span> Previous
               </a>
             </li>
@@ -43,7 +43,7 @@
             </li>
             {% if page_obj.has_next %}
             <li class="page-item">
-              <a class="page-link" href="?page={{page_obj.next_page_number}}" class="next">
+              <a class="page-link" href="{{ next_url }}" class="next">
                 Next <span class="fas fa-chevron-right" aria-hidden="true"></span>
               </a>
             </li>
@@ -80,7 +80,7 @@
       <ul class="pagination pagination-sm">
         {% if page_obj.has_previous %}
         <li class="page-item">
-          <a class="page-link" href="?page={{page_obj.previous_page_number}}">
+          <a class="page-link" href="{{ previous_url }}">
             <span class="fas fa-chevron-left" aria-hidden="true"></span> Previous
           </a>
         </li>
@@ -90,7 +90,7 @@
         </li>
         {% if page_obj.has_next %}
         <li class="page-item">
-          <a class="page-link" href="?page={{page_obj.next_page_number}}" class="next">
+          <a class="page-link" href="{{ next_url }}" class="next">
             Next <span class="fas fa-chevron-right" aria-hidden="true"></span>
           </a>
         </li>


### PR DESCRIPTION
Bug Fixes:
* Updated the SortSearchMixin to handle pagination correctly. Now when a search has been done, and you hit next/previous, the search query will follow the pagination.
* Ensure the Preview Recipient Groups search form points at the correct page.

Motivation/Context:
* It's super annoying looking for stuff right now with this not working.

Fixes #4 🎉 
Fixes #35 🎊 