### PR TITLE
Fixed excess space between links in email previews

### DIFF
--- a/manager/models.py
+++ b/manager/models.py
@@ -544,7 +544,7 @@ class Email(models.Model):
         soup = BeautifulSoup(html, 'html.parser')
         explanation = BeautifulSoup(html_explanation, 'html.parser')
         soup.body.insert(0, explanation)
-        html = soup.prettify('us-ascii')
+        html = str(soup.encode('us-ascii'))
 
         # The recipients for the preview emails aren't the same as regular
         # recipients. They are defined in the comma-separate field preview_recipients


### PR DESCRIPTION
Replaced `soup.prettify()` with `str(soup)` when returning email preview markup to avoid extra whitespace insertion between link text.

Resolves #45 🎉 