### PR TITLE
Ampersand Hotfix

### DIFF
--- a/manager/views.py
+++ b/manager/views.py
@@ -13,6 +13,7 @@ import json
 import subprocess
 import sys
 import csv
+import HTMLParser
 
 from django.conf import settings
 from django.contrib import messages
@@ -985,6 +986,7 @@ def redirect(request):
     position = request.GET.get('position', None)
     recipient_id = request.GET.get('recipient', None)
     mac = request.GET.get('mac', None)
+    parser = HTMLParser.HTMLParser()
 
     if not url_string or not position or not recipient_id or not mac or not instance_id:
         raise Http404("Poll does not exist")
@@ -1041,7 +1043,8 @@ def redirect(request):
             pass
         # Decode any encoded characters to ensure things like
         # UTM params work appropriately
-        url_string = urllib.unquote(url_string)
+
+        url_string = parser.unescape(url_string)
         return HttpResponseRedirect(url_string)
 
 

--- a/manager/views.py
+++ b/manager/views.py
@@ -1039,6 +1039,9 @@ def redirect(request):
         except Exception, e:
             log.error(str(e))
             pass
+        # Decode any encoded characters to ensure things like
+        # UTM params work appropriately
+        url_string = urllib.unquote(url_string)
         return HttpResponseRedirect(url_string)
 
 


### PR DESCRIPTION
Bug Fixes:
* Ensure URLs are unescaped at least once before redirecting to ensure ampersands that are escaped - `&amp;` - are unescaped - `&`.