### PR TITLE
Trackable URL regex improvements

### DIFF
--- a/manager/models.py
+++ b/manager/models.py
@@ -951,7 +951,7 @@ class Instance(models.Model):
         if not self.urls_tracked:
             return []
 
-        hrefs = re.findall('<a(?:[ \w\-\=\"]+)?href=\"([^\"]+)\"', self.sent_html)
+        hrefs = re.findall('<a(?:[ \w\-\=\"\:\;\#\'\(\)]+)?href=\"([^\"]+)\"', self.sent_html)
         urls  = []
 
         for href in hrefs:

--- a/manager/models.py
+++ b/manager/models.py
@@ -951,7 +951,7 @@ class Instance(models.Model):
         if not self.urls_tracked:
             return []
 
-        hrefs = re.findall('<a(?:[ \w\-\=\"\:\;\#\'\(\)]+)?href=\"([^\"]+)\"', self.sent_html)
+        hrefs = re.findall('<a(?:[\s\w\-\"=\':;#\(\),]+)?href=\"([^\"]+)\"', self.sent_html)
         urls  = []
 
         for href in hrefs:


### PR DESCRIPTION
Updated the regex used to detect trackable URLs in an email's HTML to accommodate for more types of content before the `href` attribute, such as `style="..."`.