### PR TITLE
Data Export (Part 1/?) - The Fellowship of the Email Data

### DIFF
--- a/manager/management/commands/export-data.py
+++ b/manager/management/commands/export-data.py
@@ -14,8 +14,6 @@ class Command(BaseCommand):
 
     filename = ''
     before = None
-    remove_exported = False
-    instances_to_remove = []
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -32,24 +30,12 @@ class Command(BaseCommand):
             default=None
         )
 
-        parser.add_argument(
-            '--remove-exported',
-            dest='remove_exported',
-            type=bool,
-            help='Remove the exported records',
-            default=False
-        )
-
     def handle(self, *args, **options):
         self.filename = options['output']
         self.before = options['before_date']
-        self.remove_exported = options['remove_exported']
 
         records = self.get_records()
         self.write_records(records)
-
-        if self.remove_exported:
-            self.remove_records()
 
     def get_records(self):
         retval = Email.objects.all()
@@ -134,15 +120,5 @@ class Command(BaseCommand):
 
                             writer.writerow(line)
 
-                            if self.remove_exported:
-                                self.instances_to_remove.append(instance.pk)
-
                             pbar.update(1)
-
-    def remove_records(self):
-        records = Instance.objects.filter(pk__in=self.instances_to_remove)
-        try:
-            records.delete()
-        except:
-            raise CommandError("There was a problem deleting the old records.")
 

--- a/manager/management/commands/export-data.py
+++ b/manager/management/commands/export-data.py
@@ -87,7 +87,7 @@ class Command(BaseCommand):
             writer = csv.DictWriter(file, fieldnames=fieldnames)
             writer.writeheader()
 
-            limit = 5
+            limit = 20
             offset = 0
             count = 0
 
@@ -105,7 +105,12 @@ class Command(BaseCommand):
 
                     email_title = record.title
 
-                    for x in xrange(instances.count() / limit):
+                    pages = instance_count / limit
+
+                    if pages < 1:
+                        pages = 1
+
+                    for x in xrange(pages):
                         offset = x * limit
                         for instance in instances.all()[offset:offset + limit]:
                             line = {

--- a/manager/management/commands/export-data.py
+++ b/manager/management/commands/export-data.py
@@ -6,6 +6,8 @@ from manager.models import Email, Instance
 import csv
 from datetime import datetime
 
+from tqdm import tqdm
+
 class Command(BaseCommand):
     help = 'Exports email data to a csv'
 
@@ -71,7 +73,7 @@ class Command(BaseCommand):
             offset = 0
             count = 0
 
-            for record in records:
+            for record in tqdm(records):
                 count += 1
                 instances = record.instances.all()
 
@@ -81,8 +83,6 @@ class Command(BaseCommand):
                 instance_count = instances.count()
 
                 email_title = record.title
-
-                print("On record {0}/{1}. Record has {1} instances...".format(count, record_count, instance_count))
 
                 for x in xrange(instances.count() / limit):
                     offset = x * limit

--- a/manager/management/commands/export-data.py
+++ b/manager/management/commands/export-data.py
@@ -140,7 +140,7 @@ class Command(BaseCommand):
                             pbar.update(1)
 
     def remove_records(self):
-        records = Instance.objects.filter(pk__in=self.instance_to_remove)
+        records = Instance.objects.filter(pk__in=self.instances_to_remove)
         try:
             records.delete()
         except:

--- a/manager/management/commands/export-data.py
+++ b/manager/management/commands/export-data.py
@@ -87,7 +87,7 @@ class Command(BaseCommand):
             writer = csv.DictWriter(file, fieldnames=fieldnames)
             writer.writeheader()
 
-            limit = 20
+            limit = 5
             offset = 0
             count = 0
 

--- a/manager/management/commands/export-data.py
+++ b/manager/management/commands/export-data.py
@@ -1,0 +1,110 @@
+from django.core.management.base import BaseCommand, CommandError
+from django.core.management import call_command
+
+from manager.models import Email, Instance
+
+import csv
+from datetime import datetime
+
+class Command(BaseCommand):
+    help = 'Exports email data to a csv'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            'output',
+            type=str,
+            help='The path to export the file to'
+        )
+
+        parser.add_argument(
+            '--before-date',
+            dest='before_date',
+            type=lambda s: datetime.strptime(s, '%Y-%m-%d'),
+            help='Filters results to emails with instances before this date',
+            default=None
+        )
+
+    def handle(self, *args, **options):
+        filename = options['output']
+        before = options['before_date']
+
+        records = self.get_records(before)
+        self.write_records(records, filename, before)
+
+    def get_records(self, before=None):
+        retval = Email.objects.all()
+
+        if before:
+            retval = retval.filter(
+                instances__end__lt=before
+            )
+
+        return retval.distinct()
+
+    def write_records(self, records, filename, before=None):
+        record_count = records.count()
+
+        with open(filename, 'w') as file:
+            fieldnames = [
+                'Email ID',
+                'Instance ID',
+                'Title',
+                'Subject',
+                'URL',
+                'From',
+                'Friendly',
+                'Start',
+                'End',
+                'Recipients',
+                'Sent',
+                'Opens',
+                'Open Rate',
+                'Clicks',
+                'Recipients who clicked',
+                'Click Rate'
+            ]
+
+            writer = csv.DictWriter(file, fieldnames=fieldnames)
+            writer.writeheader()
+
+            limit = 20
+            offset = 0
+            count = 0
+
+            for record in records:
+                count += 1
+                instances = record.instances.all()
+
+                if before:
+                    instances = instances.filter(end__lt=before)
+
+                instance_count = instances.count()
+
+                email_title = record.title
+
+                print("On record {0}/{1}. Record has {1} instances...".format(count, record_count, instance_count))
+
+                for x in xrange(instances.count() / limit):
+                    offset = x * limit
+                    for instance in instances.all()[offset:offset + limit]:
+                        line = {
+                            'Email ID': record.id,
+                            'Instance ID': instance.id,
+                            'Title': email_title,
+                            'Subject': instance.subject,
+                            'URL': record.source_html_uri,
+                            'From': record.from_email_address,
+                            'Friendly': record.from_friendly_name,
+                            'Start': instance.start,
+                            'End': instance.end,
+                            'Recipients': instance.recipients.count(),
+                            'Sent': instance.sent_count,
+                            'Opens': instance.initial_opens,
+                            'Open Rate': instance.open_rate,
+                            'Clicks': instance.click_count,
+                            'Recipients who clicked': instance.click_recipient_count,
+                            'Click Rate': instance.click_rate
+                        }
+
+                        writer.writerow(line)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,6 @@ pyasn1-modules==0.2.2
 python-ldap==3.1.0
 pytz==2018.5
 requests==2.19.1
+tqdm==4.48.2
 urllib3==1.23
 wsgiref==0.1.2


### PR DESCRIPTION
Enhancements:
* Added a data export command that squashes data, per instance, into single rows within a csv. Currently, the CSV data is written to a file. We may update it in the future to write to a stream, so it can be sent as an attachment through an email.
* Currently the exporter will export all data, with an optional flag the limit data up to a point. For example, passing in `--before-date=2018-01-01` will export all data up to, not not including, the first day of January.