### PR TITLE
Data Export (3/3): The Return of the Key

### DIFF
--- a/manager/forms.py
+++ b/manager/forms.py
@@ -149,6 +149,10 @@ class RecipientCSVImportForm(forms.Form):
                 raise forms.ValidationError('Please specify either a new or existing group name.')
             return cleaned_data
 
+class ExportCleanupForm(forms.Form):
+    stale_record = forms.CharField(widget=forms.HiddenInput)
+    remove_emails = forms.BooleanField(help_text='When checked, any emails with 0 instances after the cleanup will be removed.')
+
 
 class RecipientAttributeCreateForm(forms.ModelForm):
 

--- a/manager/forms.py
+++ b/manager/forms.py
@@ -150,7 +150,6 @@ class RecipientCSVImportForm(forms.Form):
             return cleaned_data
 
 class ExportCleanupForm(forms.Form):
-    stale_record = forms.CharField(widget=forms.HiddenInput)
     remove_emails = forms.BooleanField(help_text='When checked, any emails with 0 instances after the cleanup will be removed.')
 
 

--- a/manager/management/commands/export-data.py
+++ b/manager/management/commands/export-data.py
@@ -1,5 +1,6 @@
 from django.core.management.base import BaseCommand, CommandError
 from django.core.management import call_command
+from django.template import loader
 from django.db.models import Count
 from manager.models import Email, Instance, StaleRecord
 
@@ -20,7 +21,11 @@ class Command(BaseCommand):
     filename = ''
     before = None
     prepare_removal = False
+    removal_hash = None
     exported = []
+
+    # Stats
+    processed = 0
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -129,50 +134,51 @@ class Command(BaseCommand):
             email_writer = csv.DictWriter(email_handler, fieldnames=fieldnames)
             email_writer.writeheader()
 
-        total_instances = Instance.objects.filter(email__in=records).count()
+        instances = Instance.objects.filter(email__in=records)
 
-        with tqdm(total=total_instances) as pbar:
-            for record in records:
-                instances = record.instances.all()
+        if self.before:
+            instances = instances.filter(end__lt=self.before)
 
-                if self.before:
-                    instances = instances.filter(end__lt=self.before)
+        with tqdm(total=instances.count()) as pbar:
+            if self.before:
+                instances = instances.filter(end__lt=self.before)
 
-                email_title = record.title
+            for instance in instances.all():
+                line = {
+                    'Email ID': instance.email.id,
+                    'Instance ID': instance.id,
+                    'Title': instance.email.title,
+                    'Subject': instance.subject,
+                    'URL': instance.email.source_html_uri,
+                    'From': instance.email.from_email_address,
+                    'Friendly': instance.email.from_friendly_name,
+                    'Start': instance.start,
+                    'End': instance.end,
+                    'Recipients': instance.recipients.count(),
+                    'Sent': instance.sent_count,
+                    'Opens': instance.initial_opens,
+                    'Open Rate': instance.open_rate,
+                    'Clicks': instance.click_count,
+                    'Recipients who clicked': instance.click_recipient_count,
+                    'Click Rate': instance.click_rate
+                }
 
-                for instance in instances.all():
-                    line = {
-                        'Email ID': record.id,
-                        'Instance ID': instance.id,
-                        'Title': email_title,
-                        'Subject': instance.subject,
-                        'URL': record.source_html_uri,
-                        'From': record.from_email_address,
-                        'Friendly': record.from_friendly_name,
-                        'Start': instance.start,
-                        'End': instance.end,
-                        'Recipients': instance.recipients.count(),
-                        'Sent': instance.sent_count,
-                        'Opens': instance.initial_opens,
-                        'Open Rate': instance.open_rate,
-                        'Clicks': instance.click_count,
-                        'Recipients who clicked': instance.click_recipient_count,
-                        'Click Rate': instance.click_rate
-                    }
+                if file_handler and file_writer:
+                    try:
+                        file_writer.writerow(line)
+                    except Exception as e:
+                        file_writer.close()
+                        raise e
 
-                    if file_handler and file_writer:
-                        try:
-                            file_writer.writerow(line)
-                        except Exception as e:
-                            file_writer.close()
-                            raise e
+                if email_handler and email_writer:
+                    email_writer.writerow(line)
 
-                    if email_handler and email_writer:
-                        email_writer.writerow(line)
+                self.exported.append(instance)
+                self.processed += 1
+                pbar.update(1)
 
-                    self.exported.append(instance)
-
-                    pbar.update(1)
+        if self.prepare_removal:
+            self.prepare_stale_record()
 
         # Make sure we close the file since we're
         # handling this manually
@@ -180,24 +186,33 @@ class Command(BaseCommand):
             file_handler.close()
 
         if email_handler:
-            self.send_email(email_handler)
+            self.send_email(email_handler, instances)
 
 
-    def send_email(self, io_stream=None):
+    def send_email(self, io_stream=None, instances=None):
+        template = loader.get_template('email/export-email.html')
+
+        if instances:
+            emails = Email.objects.filter(instances__end__lt=self.before).annotate(count_instances=Count('instances'))
+
+        context = {
+            'sent_time': datetime.now(),
+            'before': self.before,
+            'record_count': self.processed,
+            'prepare_removal': self.prepare_removal,
+            'removal_hash': self.removal_hash,
+            'instances': emails,
+            'project_url': settings.PROJECT_URL
+        }
+
+        text = template.render(context)
+
         try:
             amazon = smtplib.SMTP_SSL(settings.AMAZON_SMTP['host'], settings.AMAZON_SMTP['port'])
             amazon.login(settings.AMAZON_SMTP['username'], settings.AMAZON_SMTP['password'])
         except:
             raise Exception("Unable to connect to amazon")
         else:
-            text = '''
-<html>
-  <head></head>
-  <body>
-    <p>The attached export is all done!</p>
-  </body>
-</html>
-            '''
 
             msg = MIMEMultipart('alternative')
             msg['subject'] = 'Data Export {0}'.format(datetime.now())
@@ -234,3 +249,5 @@ class Command(BaseCommand):
         stale.save()
 
         stale.instances.add(*self.exported)
+
+        self.removal_hash = stale.removal_hash

--- a/manager/management/commands/export-data.py
+++ b/manager/management/commands/export-data.py
@@ -140,9 +140,6 @@ class Command(BaseCommand):
             instances = instances.filter(end__lt=self.before)
 
         with tqdm(total=instances.count()) as pbar:
-            if self.before:
-                instances = instances.filter(end__lt=self.before)
-
             for instance in instances.all():
                 line = {
                     'Email ID': instance.email.id,

--- a/manager/management/commands/export-data.py
+++ b/manager/management/commands/export-data.py
@@ -194,6 +194,8 @@ class Command(BaseCommand):
 
         if instances:
             emails = Email.objects.filter(instances__end__lt=self.before).annotate(count_instances=Count('instances'))
+        else:
+            emails = None
 
         context = {
             'sent_time': datetime.now(),

--- a/manager/management/commands/remove-stale.py
+++ b/manager/management/commands/remove-stale.py
@@ -34,10 +34,27 @@ class Command(BaseCommand):
             default=False
         )
 
+        parser.add_argument(
+            '--subprocess',
+            dest='subprocess',
+            type=int,
+            help='When provided, a subprocess record will be updated on each tick of the progress bar',
+            default=None
+        )
+
     def handle(self, *args, **options):
         self.record_hash = options['record_hash']
         self.remove_emails = options['remove_empty_emails']
         self.quiet = options['quiet']
+        self.subprocess = options['subprocess']
+
+        if self.subprocess:
+            try:
+                tracker = SubprocessStatus.objects.get(pk=self.subprocess)
+                self.subprocess = tracker
+            except SubprocessStatus.DoesNotExist:
+                raise CommandError("The subprocess provided does not exist")
+
 
         self.clean()
 
@@ -50,13 +67,20 @@ class Command(BaseCommand):
         instances = stale.instances.all()
         emails = Email.objects.filter(instances__in=instances)
 
+        if self.subprocess:
+            self.subprocess.total_units = instances.count()
+            self.subprocess.status = 'In Progress'
+            self.subprocess.status.save()
+
         if not self.quiet:
             delete = self.confirm("Delete {0} instances? [Y/n]: ".format(instances.count()), True)
 
             if delete == False:
                 return
 
-        instances.delete()
+        for idx, instance in enumerate(instances.all()):
+            instance.delete()
+            self.update_status('In Progress', '', idx + 1)
 
         if self.remove_emails:
             emails = emails.filter(instances=0)
@@ -67,8 +91,24 @@ class Command(BaseCommand):
                 if delete == False:
                     return
 
+        self.update_status('Complete', '')
 
-            emails.delete()
+
+    def update_status(self, status, error, current_unit):
+        if (self.subprocess and status == "Completed") :
+            self.tracker.status = "Completed"
+            self.tracker.error = ""
+            self.tracker.current_unit = self.tracker.total_units
+            self.tracker.save()
+
+        if (self.subprocess and
+            (current_unit % self.update_factor == 0
+            or current_unit == self.tracker.total_units)
+            or error != ""):
+            self.tracker.status = status
+            self.tracker.error = error
+            self.tracker.current_unit = current_unit
+            self.tracker.save()
 
     def confirm(self, message, default=None):
         result = input('%s ' % message)

--- a/manager/urls.py
+++ b/manager/urls.py
@@ -22,6 +22,7 @@ urlpatterns = [
     url(r'^email/instance/(?P<pk>\d+)/cancel/$',    login_required(instance_cancel),                                     name='manager-instance-cancel'),
     url(r'^instance/json/$',                        login_required(instance_json_feed),                         name='manager-instance-json'),
     url(r'^emails/$',                               login_required(EmailListView.as_view()),                    name='manager-emails'),
+    url(r'^export-cleanup/$',                        login_required(ExportCleanupView.as_view()),                        name='manager-export-cleanup'),
 
     # Recipients
     url(r'^recipientgroups/$',                        login_required(RecipientGroupLiveListView.as_view()),      name='manager-recipientgroups'),

--- a/manager/views.py
+++ b/manager/views.py
@@ -1176,6 +1176,7 @@ class ExportCleanupView(FormView):
         context = super(ExportCleanupView, self).get_context_data(**kwargs)
 
         removal_hash = self.request.GET.get('hash', None)
+        context['hash'] = removal_hash
 
         if removal_hash:
             try:

--- a/manager/views.py
+++ b/manager/views.py
@@ -1212,7 +1212,8 @@ class ExportCleanupView(FormView):
                 'manage.py',
                 'remove-stale',
                 removal_hash,
-                '--quiet=True'
+                '--quiet=True',
+                '--subprocess={0}'.format(tracker.pk)
             ]
 
             if remove_emails:

--- a/templates/email/export-email.html
+++ b/templates/email/export-email.html
@@ -304,7 +304,7 @@
         <tr>
         <td class="ccollapse100" style="font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; font-size: 32px; line-height: 1.5; padding-top: 32px;">
           <table class="paragraphtable" style="width: 100%;"><tbody><tr><td style="width: 100%; font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; padding: 0px 0px 16px 0px; margin: 0; text-align: center;">
-            <a href="{{ project_url }}{% url 'manager-remove-stale' %}?hash={{removal_hash}}">Remove Records</a>
+            <a href="{{ project_url }}{% url 'manager-export-cleanup' %}?hash={{removal_hash}}">Remove Records</a>
 	      </td>
 				</tr></tbody></table>                  </td></tr>
         {% endif %}

--- a/templates/email/export-email.html
+++ b/templates/email/export-email.html
@@ -1,0 +1,343 @@
+
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html lang="en">
+
+<head>
+  <meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
+  <meta name="format-detection" content="telephone=no">
+  <meta name="viewport" content="initial-scale=1.0">
+
+  <title>
+    Email Export  </title>
+
+  <style type="text/css">
+  @font-face {
+    font-family: "UCF-Sans-Serif-Alt";
+    font-style: normal;
+    font-weight: 400;
+    src: url('https://s3.amazonaws.com/web.ucf.edu/email/common-assets/fonts/ucfsansserifalt-medium-webfont.woff2') format("woff2"),
+	  url('https://s3.amazonaws.com/web.ucf.edu/email/common-assets/fonts/ucfsansserifalt-medium-webfont.woff') format("woff");
+	mso-font-alt: 'Arial';
+  }
+  @font-face {
+    font-family: "UCF-Sans-Serif-Alt";
+    font-style: normal;
+    font-weight: 500;
+    src: url('https://s3.amazonaws.com/web.ucf.edu/email/common-assets/fonts/ucfsansserifalt-semibold-webfont.woff2') format("woff2"),
+	  url('https://s3.amazonaws.com/web.ucf.edu/email/common-assets/fonts/ucfsansserifalt-semibold-webfont.woff') format("woff");
+	mso-font-alt: 'Arial';
+  }
+  @font-face {
+    font-family: "UCF-Sans-Serif-Alt";
+    font-style: normal;
+    font-weight: 700;
+    src: url('https://s3.amazonaws.com/web.ucf.edu/email/common-assets/fonts/ucfsansserifalt-bold-webfont.woff2') format("woff2"),
+	  url('https://s3.amazonaws.com/web.ucf.edu/email/common-assets/fonts/ucfsansserifalt-bold-webfont.woff') format("woff");
+	mso-font-alt: 'Arial';
+  }
+
+
+  /* CSS Resets */
+
+  .ReadMsgBody {
+    width: 100%;
+    background-color: #ffffff;
+  }
+
+  .ExternalClass {
+    width: 100%;
+    background-color: #ffffff;
+  }
+
+  .ExternalClass,
+  .ExternalClass p,
+  .ExternalClass span,
+  .ExternalClass font,
+  .ExternalClass td,
+  .ExternalClass div {
+    line-height: 100%;
+  }
+
+  * {
+    zoom: 1;
+  }
+
+  body {
+    -webkit-text-size-adjust: none; /* ios likes to enforce a minimum font size of 13px; kill it with this */
+    -ms-text-size-adjust: none;
+	margin: 0;
+    padding: 0;
+  }
+
+  table {
+    border-spacing: 0;
+  }
+
+  table td {
+    border-collapse: collapse;
+  }
+
+  a {
+    color: #006699;
+  }
+
+  @media all and (min-width: 641px) {
+      td.text-right-desktop,
+      th.text-right-desktop {
+          text-align: right !important;
+      }
+
+      td.text-left-desktop,
+      th.text-left-desktop {
+          text-align: left !important;
+      }
+  }
+
+  @media all and (max-width: 640px) {
+
+  /* The outermost wrapper table */
+	table[class="wrapperOuter"] {
+		margin: 10px 0 0 !important;
+		width: 100% !important;
+	}
+
+	/* The firstmost inner tables, which should be padded at mobile sizes */
+	table[class="wrapperInner"] {
+		border-left: 0px solid transparent !important;
+		border-right: 0px solid transparent !important;
+		margin: 0 !important;
+		padding-left: 15px;
+		padding-right: 15px;
+		width: 100% !important;
+	}
+
+    /* The outermost wrapper table */
+    table.t640 {
+      width: 100% !important;
+      border-left: 0px solid transparent !important;
+      border-right: 0px solid transparent !important;
+      margin: 0 !important;
+    }
+
+    /* The firstmost inner tables, which should be padded at mobile sizes */
+    table.t564 {
+      width: 100% !important;
+      padding-left: 15px;
+      padding-right: 15px;
+      padding-top: 15px !important;
+      border-left: 0px solid transparent !important;
+      border-right: 0px solid transparent !important;
+      margin: 0 !important;
+    }
+
+    /* Generic class for a table column that should collapse to 100% width at mobile sizes (with bottom padding) */
+    td.ccollapse100pb {
+      display: block !important;
+      overflow: hidden;
+      width: 100% !important;
+      float: left;
+      clear: both;
+      margin-left: 0 !important;
+      margin-right: 0 !important;
+      padding-left: 0 !important;
+      padding-right: 0 !important;
+      padding-bottom: 20px !important;
+      border-left: 0px solid transparent !important;
+      border-right: 0px solid transparent !important;
+    }
+
+    /* Generic class for a table column that should collapse to 100% width at mobile sizes (with top padding) */
+    td.ccollapse100pt {
+      display: block !important;
+      overflow: hidden;
+      width: 100% !important;
+      float: left;
+      clear: both;
+      margin-left: 0 !important;
+      margin-right: 0 !important;
+      padding-left: 0 !important;
+      padding-right: 0 !important;
+      padding-top: 20px !important;
+      border-left: 0px solid transparent !important;
+      border-right: 0px solid transparent !important;
+    }
+
+    /* Generic class for a table column that should collapse to 50% width at mobile sizes (with bottom padding) */
+    td.ccollapse50pb {
+      display: block !important;
+      overflow: hidden;
+      width: 50% !important;
+      float: left;
+      clear: both;
+      margin-left: 0 !important;
+      margin-right: 0 !important;
+      padding-left: 0 !important;
+      padding-right: 0 !important;
+      padding-bottom: 20px !important;
+      border-left: 0px solid transparent !important;
+      border-right: 0px solid transparent !important;
+    }
+
+    /* Generic class for a table column that should collapse to 100% width at mobile sizes */
+    td.ccollapse100 {
+      display: block !important;
+      overflow: hidden;
+      clear: both;
+      width: 100% !important;
+      float: left !important;
+      margin-left: 0 !important;
+      margin-right: 0 !important;
+      padding-left: 0 !important;
+      padding-right: 0 !important;
+      border-left: 0px solid transparent !important;
+      border-right: 0px solid transparent !important;
+    }
+
+    /* Generic class for a table within a column that should be forced to 100% width at mobile sizes */
+    table.tcollapse100 {
+      width: 100% !important;
+      margin-left: 0 !important;
+      margin-right: 0 !important;
+      padding-left: 0 !important;
+      padding-right: 0 !important;
+      border-left: 0px solid transparent !important;
+      border-right: 0px solid transparent !important;
+    }
+
+    /* Forces an image to fit 100% width of its parent */
+    img.responsiveimg {
+      max-width: none !important;
+      width: 100% !important;
+    }
+
+    img.responsiveimgmw {
+      max-width: 100% !important;
+    }
+
+    /* remove padding since 100% width */
+    img.responsiveimgpb {
+      width: 100% !important;
+      margin-left: 0 !important;
+      margin-right: 0 !important;
+      padding-left: 0 !important;
+      padding-right: 0 !important;
+      padding-bottom: 20px !important;
+    }
+  }
+</style>
+</head>
+
+<body style="background-color: #ffffff;">
+<table width="100%" align="center" style="width: 100% !important; table-layout: fixed; background-color: #f1f1f1;">
+    <tbody>
+      <tr>
+        <td align="center" style="padding: 0;">
+          <table class="wrapperOuter" width="640" align="center" style="background-color: #ffffff; width: 640px; margin-top: 0 !important; margin-bottom: 0; border-spacing: 0; border-collapse: collapse;">
+            <tbody>
+              <tr>
+                <td align="center" style="padding: 0;">
+                  <table class="wrapperInner" width="600" align="center" style="border-spacing: 0; border-collapse: collapse;">
+                    <tbody>
+                      <tr>
+                        <td style="padding: 0;">
+                          <table class="t640" width="640" align="center">
+                            <tbody>
+                              <tr>
+                                <td style="padding: 0;">
+                                  <img src="https://s3.amazonaws.com/web.ucf.edu/email/postmaster-templates/pro-banner.png" alt="UCF banner" class="responsiveimg">                                </td>
+                              </tr>
+                              <tr>
+                                <td>
+                                  <table class="t564" width="564" align="center" style="padding-top: 15px;">
+                                  <tbody>
+                                    <tr>
+                                      <td style="padding-bottom: 0;">
+
+<table class="tcollapse100" width="564" border="0" align="center">
+  <tbody>
+    <tr>
+    <td style="padding-left: 0; padding-right: 0; font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; font-size: 35px; font-weight: bold; padding-top: 20px; padding-bottom: 12px; line-height: 1.1; color: #000; text-align: left; border-bottom: 1px solid #fc0;" align="left">Postmaster Data Export</td>
+  </tr>
+    <tr>
+      <td style="padding-left: 0; padding-right: 0; font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; font-size: 24px; font-weight: bold; padding-top: 12px; padding-bottom: 30px; line-height: 1.1; color: #777; text-align: left; text-transform: uppercase;" align="left">{{ sent_time }}</td>
+    </tr>
+    <tr>
+    <td class="ccollapse100" style="width: 100%;">
+    <table class="tcollapse100" align="center" style="width: 100%;">
+      <tbody>
+      <tr>
+        <td class="ccollapse100" style="font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; font-size: 15px; line-height: 1.5;">
+          <table class="paragraphtable" style="width: 100%;"><tbody><tr><td style="width: 100%; font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; padding: 0px 0px 16px 0px; margin: 0;">
+            An export of instance data{% if before %} up to {{ before }}{% endif %} has completed and is attached. The attachment contains {{ record_count }} instance records.
+	      </td>
+        </tr></tbody></table>                  </td></tr>
+        {% if prepare_removal %}
+        <tr>
+          <td class="ccollapse100" style="font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; font-size: 15px; line-height: 1.5;">
+            <table class="paragraphtable" style="width: 100%;"><tbody><tr><td style="width: 100%; font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; padding: 0px 0px 16px 0px; margin: 0;">
+              The following email instances have been prepared for removal following the export. Please review the records and then click the link below to remove them.
+          </td>
+          </tr></tbody></table>                  </td></tr>
+        <tr>
+          <td class="ccollapse100" style="margin-bottom: 20px;">
+            {% if instances %}
+            <table style="width: 100%">
+              <thead>
+                <tr>
+                  <th style="padding: 10px; border: 1px solid black; border-collapse: collapse;">Email Name</th>
+                  <th style="padding: 10px; border: 1px solid black; border-collapse: collapse;">Instance Count</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for email in instances %}
+                <tr>
+                  <td style="padding: 10px; border: 1px solid black; border-collapse: collapse;">{{ email.title }}</td>
+                  <td style="padding: 10px; border: 1px solid black; border-collapse: collapse; text-align: right;">{{ email.count_instances }}</td>
+                </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+            {% endif %}
+          </td>
+        </tr>
+        <tr>
+        <td class="ccollapse100" style="font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; font-size: 32px; line-height: 1.5; padding-top: 32px;">
+          <table class="paragraphtable" style="width: 100%;"><tbody><tr><td style="width: 100%; font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; padding: 0px 0px 16px 0px; margin: 0; text-align: center;">
+            <a href="{{ project_url }}{% url 'manager-remove-stale' %}?hash={{removal_hash}}">Remove Records</a>
+	      </td>
+				</tr></tbody></table>                  </td></tr>
+        {% endif %}
+      </tr>
+      </tbody>
+    </table>
+    </td>
+  </tr>
+  </tbody>
+</table>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td style="padding: 0;">
+                                                                                    </td>
+                                    </tr>
+                                  </tbody>
+                                </table>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </tr>
+    </tbody>
+  </table>
+</body>
+
+</html>

--- a/templates/form-control-group.html
+++ b/templates/form-control-group.html
@@ -14,7 +14,9 @@
       <small class="form-text text-muted">{{field.help_text}}</small>
     </div>
   {% else %}
+    {% if not field.is_hidden %}
     <label for="{{field.id}}" class="col-form-label col-md-3 text-left text-md-right">{{field.label}} {% if field.field.required %}*{% endif %}</label>
+    {% endif %}
     <div class="col-md-9">
       {% if field.field.required %}
         {% if field|is_file %}

--- a/templates/manager/export-cleanup.html
+++ b/templates/manager/export-cleanup.html
@@ -1,0 +1,51 @@
+{% extends 'base.html' %}
+{% block page-body %}
+<h1 class="h2 headling-underline">Export Clean Up</h1>
+{% if stale %}
+<p class="lead">Are you sure you want to delete the following records?</p>
+<table class="table">
+  <thead>
+    <tr>
+      <th>Instances</th>
+      <th>Emails (optional)</th>
+      {% if earliest %}
+      <th>Earliest Instance</th>
+      {% endif %}
+      {% if latest %}
+      <th>Latest Instance</th>
+      {% endif %}
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>{{ stale.instances.count }}</td>
+      <td>{{ stale.emails.count }}</td>
+      {% if earliest %}
+      <td>{{ earliest }}</td>
+      {% endif %}
+      {% if latest %}
+      <td>{{ latest }}</td>
+      {% endif %}
+    </tr>
+  </tbody>
+</table>
+{% endif %}
+<form class="form-horizontal" action="" method="post">
+  <fieldset>
+    {% for error in form.non_field_errors %}
+      <div class="alert alert-error">
+        {{error}}
+      </div>
+    {% endfor %}
+    {% for field in form %}
+      {% include 'form-control-group.html' %}
+    {% endfor %}
+  </fieldset>
+  <div class="form-group row">
+    <div class="offset-sm-3 col-sm-9">
+      <button type="submit" class="btn btn-danger"><span class="fas fa-trash" aria-hidden="true"></span> Delete</button>
+      <a href="{% url 'manager-home' %}" class="btn btn-default"><span class="fas fa-minus" aria-hidden="true"></span> Cancel</a>
+    </div>
+  </div>
+</form>
+{% endblock %}

--- a/templates/manager/export-cleanup.html
+++ b/templates/manager/export-cleanup.html
@@ -50,9 +50,9 @@
 {% else %}
 {% if not hash %}
 <p class="lead">This page is not accessible without a record cleanup key.</p>
-<p><a href="{% url 'manager-home' %}">Return Home</a></p>
 {% else %}
 <p class="lead">An export cleanup record with the hash provided could not be found.</p>
 {% endif %}
+<p><a class="btn btn-primary" href="{% url 'manager-home' %}">Return Home</a></p>
 {% endif %}
 {% endblock %}

--- a/templates/manager/export-cleanup.html
+++ b/templates/manager/export-cleanup.html
@@ -29,7 +29,6 @@
     </tr>
   </tbody>
 </table>
-{% endif %}
 <form class="form-horizontal" action="" method="post">
   <fieldset>
     {% for error in form.non_field_errors %}
@@ -48,4 +47,12 @@
     </div>
   </div>
 </form>
+{% else %}
+{% if not hash %}
+<p class="lead">This page is not accessible without a record cleanup key.</p>
+<p><a href="{% url 'manager-home' %}">Return Home</a></p>
+{% else %}
+<p class="lead">An export cleanup record with the hash provided could not be found.</p>
+{% endif %}
+{% endif %}
 {% endblock %}

--- a/templates/manager/subprocess-status.html
+++ b/templates/manager/subprocess-status.html
@@ -2,7 +2,7 @@
 {% block page-body %}
 <h1 class="h2 heading-underline">{{ object.name }}</h1>
 <div class="alert alert-info">
-  <p>This subprocess is in progress: <span class="completed">0 of 0</span> {{ object.unit_name }} imported.</p>
+  <p>This subprocess is in progress: <span class="completed">0 of 0</span> {{ object.unit_name }} processed.</p>
   <p class="error-text"></p>
   <p class="badge badge-info">{{ object.status }}</p>
   <div class="progress send-progress">


### PR DESCRIPTION
As Codo stood above the fires of Mount Data Deletion, a fey light gleamed in his eyes. There was a greediness, a protectiveness in that gaze, a desire to hold onto the precious email data forever. Something held him back from casting the precious into the fiery chasm: a confirmation screen. Deftly, ignoring the heat rising up from below, a strange creature leaped onto Codo, stripping the data from him, and gleefully punched the Delete button, falling into perdition's flames, never to be seen again.

Enhancements:
* Created a `manager-export-cleanup` view that displays basic stats and prompts users before calling the `remove-stale` command and deleting the data. The view requires the `removal_hash` in order to be used. The hash acts as a "key" to prevent a user from being able to randomly pick a PK of a `StaleRecord` that might be in the system and then delete the data tracked within that record.
* Updated the export email to include a link that takes to the user to the `manager-export-cleanup` view.
* Updated the `remove-stale` command to report its status back to a `SubprocessStatus` object during execution if the primary key is provided for one.