### PR TITLE
Data Export (Epilogue): The Scouring of the Shire

### DIFF
--- a/manager/management/commands/export-data.py
+++ b/manager/management/commands/export-data.py
@@ -4,7 +4,7 @@ from django.template import loader
 from django.db.models import Count
 from manager.models import Email, Instance, StaleRecord
 
-import csv
+import unicodecsv as csv
 from datetime import datetime
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
@@ -164,7 +164,7 @@ class Command(BaseCommand):
                     try:
                         file_writer.writerow(line)
                     except Exception as e:
-                        file_writer.close()
+                        file_handler.close()
                         raise e
 
                 if email_handler and email_writer:

--- a/manager/management/commands/remove-stale.py
+++ b/manager/management/commands/remove-stale.py
@@ -91,6 +91,8 @@ class Command(BaseCommand):
                 if delete == False:
                     return
 
+            emails.delete()
+
         self.update_status('Complete', '', self.tracker.total_units)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,6 @@ python-ldap==3.1.0
 pytz==2018.5
 requests==2.19.1
 tqdm==4.48.2
+unicodecsv==0.14.1
 urllib3==1.23
 wsgiref==0.1.2


### PR DESCRIPTION
Upon returning home, our heroes found lazy and impatient developers had allowed all kind of bugs into the Shire, and were forced to rally and expel them forever!

Bug Fixes:
* Updated code to make sure it's the `file_handler` we're closing when an exception occurs. This is what actually puts a write lock on the file on unix systems, not the `CSVDictWriter`.
* Replaced the default csv library with `unicodecsv` which handles all those pesky unicode/ascii errors we usually have to deal with manually.
* Added the line that _actually_ deletes the email during the `remove-stale` task.