### PR TITLE
Click/Open Count Optimizations

### DIFF
--- a/manager/models.py
+++ b/manager/models.py
@@ -964,7 +964,7 @@ class Instance(models.Model):
         the instance has opened the email, and should be included
         in this list.
         """
-        openers = Recipient.objects.filter(pk__in=self.opens.values_list('recipient__id', flat=True))
+        openers = Recipient.objects.filter(pk__in=self.opens.values_list('recipient__pk', flat=True))
         clickers = self.click_recipients
         return openers.union(clickers)
 
@@ -1039,7 +1039,7 @@ class Instance(models.Model):
         The recipients who clicked on
         at least one URL in the email.
         """
-        return Recipient.objects.filter(pk__in=self.clicks.values_list('recipient__id', flat=True))
+        return Recipient.objects.filter(pk__in=self.clicks.values_list('recipient__pk', flat=True))
 
     @property
     def click_recipient_count(self):


### PR DESCRIPTION
<!---
Thank you for contributing to PostMaster.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/PostMaster/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Optimized the query for the `open_recipient_count` and `click_recipient_count` properties by removing the Recipient object query. In both instances, we're only concerned with the count of unique recipients, so there isn't a need to actually query the recipients. We can calculate the count by taking the length of a `set()` of recipient ids.

**Motivation and Context**
Both properties were running inefficiently when being calculated for instances with a large number of URLClicks, to the point that pages were timing out. This new method of getting the counts should prevent that.

**How Has This Been Tested?**
Changes are available for review in both DEV and QA, and was tested in production (manually calculating in the shell) using one of the instances that was timing out.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
