### PR TITLE
Segment rule query refinements by email, instance opens

### DIFF
--- a/manager/models.py
+++ b/manager/models.py
@@ -275,19 +275,29 @@ class SegmentRule(models.Model):
         elif self.field == 'opened_email':
             # If the recipient opened any instance of a specific email
             # (includes clicks--matches logic in Instance.open_recipients)
-            return Q(
+            recipient_opens = Recipient.objects.filter(
                 instances_opened__instance__email=int(self.value)
-            ) | Q(
+            )
+            recipient_clicks = Recipient.objects.filter(
                 urls_clicked__url__instance__email=int(self.value)
             )
+
+            recipient_pks = list(recipient_opens.union(recipient_clicks).values_list('pk', flat=True))
+
+            return Q(pk__in=recipient_pks)
         elif self.field == 'opened_instance':
             # If the recipient opened a particular instance
             # (includes clicks--matches logic in Instance.open_recipients)
-            return Q(
+            recipient_opens = Recipient.objects.filter(
                 instances_opened__instance=int(self.value)
-            ) | Q(
+            )
+            recipient_clicks = Recipient.objects.filter(
                 urls_clicked__url__instance=int(self.value)
             )
+
+            recipient_pks = list(recipient_opens.union(recipient_clicks).values_list('pk', flat=True))
+
+            return Q(pk__in=recipient_pks)
         elif self.field == 'clicked_link':
             # If the recipient clicked on a particular URL
             return Q(urls_clicked__url__name=self.value)

--- a/manager/models.py
+++ b/manager/models.py
@@ -273,13 +273,21 @@ class SegmentRule(models.Model):
             # If the recipient received a particular instance
             return Q(instance=int(self.value))
         elif self.field == 'opened_email':
-            # TODO: See if we can map this to `open_recipients` on instances
-            # If the recipient opened any instance of an email
-            return Q(instances_opened__instance__email=int(self.value))
+            # If the recipient opened any instance of a specific email
+            # (includes clicks--matches logic in Instance.open_recipients)
+            return Q(
+                instances_opened__instance__email=int(self.value)
+            ) | Q(
+                urls_clicked__url__instance__email=int(self.value)
+            )
         elif self.field == 'opened_instance':
-            # TODO: See if we can map this to `open_recipients` on instances
-            # If the recipient opened a specific instance
-            return Q(instances_opened__instance=int(self.value))
+            # If the recipient opened a particular instance
+            # (includes clicks--matches logic in Instance.open_recipients)
+            return Q(
+                instances_opened__instance=int(self.value)
+            ) | Q(
+                urls_clicked__url__instance=int(self.value)
+            )
         elif self.field == 'clicked_link':
             # If the recipient clicked on a particular URL
             return Q(urls_clicked__url__name=self.value)


### PR DESCRIPTION
<!---
Thank you for contributing to PostMaster.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/PostMaster/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
Resolves some TODOs that ensure segment rules by email/instance opens include recipients that only clicked on a link in an instance (e.g. if they had image blocking enabled in their email client).

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
So that these rules' results are in alignment with how we calculate total opens per instance (recipients that opened + recipients that clicked a link).

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Tested locally + in Dev

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
