### PR TITLE
RecipientGroup/Segment Aggregation Bug Fix

### DIFF
--- a/manager/models.py
+++ b/manager/models.py
@@ -754,9 +754,9 @@ class Email(models.Model):
         retval = None
         for recipient_group in self.recipient_groups.all():
             if retval is None:
-                retval = recipient_group.recipients.all()
+                retval = recipient_group.recipients.all().distinct()
             else:
-                retval = retval | recipient_group.recipients.all()
+                retval = retval | recipient_group.recipients.all().distinct()
 
         for segment in self.segments.all():
             if retval is None:


### PR DESCRIPTION
<!---
Thank you for contributing to PostMaster.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/PostMaster/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Corrects a bug created by trying to combine the non-distinct queries returned by RecipientGroups with the distinct queries returned by Segments. To correct this, when combining the two within the `recipients` property of `Email`, all recipient groups get the additional call to `distinct()` before being added to the return value.

**Motivation and Context**
It's a bug!

**How Has This Been Tested?**
Changes are available for review in DEV and QA. The easiest way to demonstrate is to create an email that uses both recipient groups and segments, and then to call the `email.recipients` property from the shell. There should be no error and a queryset of recipients should be returned.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
