### PR TITLE
Added migration to update db, tables to utf8mb4

### DIFF
--- a/manager/migrations/0032_db_collation.py
+++ b/manager/migrations/0032_db_collation.py
@@ -1,0 +1,43 @@
+from django.db import migrations
+
+
+def alter_collation(character_set, collation, schema_editor):
+	with schema_editor.connection.cursor() as cursor:
+		# set for database
+		print('Altering database…')
+		cursor.execute(
+			f'ALTER DATABASE CHARACTER SET {character_set} COLLATE {collation};'
+		)
+		# set for tables (and convert data)
+		cursor.execute(
+			'SHOW TABLES;'
+		)
+		for table, in cursor.fetchall():
+			print(f'Altering table `{table}`…')
+			cursor.execute(
+				f'ALTER TABLE {table} CONVERT TO CHARACTER '
+				f'SET {character_set} COLLATE {collation}'
+			)
+
+
+def alter_collation_forwards(apps, schema_editor):
+	'''
+	Sets *collation* and *character_set* for a database and its tables.
+	Also converts data in the tables if necessary.
+	'''
+	return alter_collation('utf8mb4', 'utf8mb4_general_ci', schema_editor)
+
+
+def alter_collation_reverse(apps, schema_editor):
+	return alter_collation('latin1', 'latin1_swedish_ci', schema_editor)
+
+
+class Migration(migrations.Migration):
+
+	dependencies = [
+		('manager', '0031_auto_20220111_1554'),
+	]
+
+	operations = [
+		migrations.RunPython(alter_collation_forwards, alter_collation_reverse),
+	]

--- a/manager/migrations/0032_db_collation.py
+++ b/manager/migrations/0032_db_collation.py
@@ -12,7 +12,7 @@ def alter_collation(character_set, collation, schema_editor):
 		cursor.execute(
 			'SHOW TABLES;'
 		)
-		for table, in cursor.fetchall():
+		for table in cursor.fetchall():
 			print(f'Altering table `{table}`…')
 			cursor.execute(
 				f'ALTER TABLE {table} CONVERT TO CHARACTER '

--- a/settings_local.template.py
+++ b/settings_local.template.py
@@ -38,6 +38,12 @@ DATABASES = {
         'HOST'    : '',
         # Set to empty string for default. Not used with sqlite3.
         'PORT'    : '',
+        # Required after running the `manager` app migration #0032.
+        # If you're running an older version of the app that hasn't
+        # applied this migration yet, comment this out:
+        'OPTIONS': {
+            'charset': 'utf8mb4'
+        }
     },
     # Currently on the database name needs to be filled in for the rds_warehouse
     # database. It is only used in the recipient-importer script.


### PR DESCRIPTION
<!---
Thank you for contributing to PostMaster.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/PostMaster/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
See title.  This migration will adjust the collation and character set for the Postmaster db and tables and columns within.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Short answer: We've been asked to support emojis in emails. 📧

Long(er) answer: Because this project was initially set up using `latin1_swedish_ci`/`latin1` everywhere, and we want to switch collations to `utf8mb4_general_ci` to support a wider character set--particularly in Instance/PreviewInstance `sent_html` and Email `subject`'s.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reverse migration has been tested locally; forward migration has been tested locally and in Dev.  The reverse migration will bomb if content outside of the latin1 charset exists in the db, but this is to be expected since `latin1_swedish_ci`/`latin1` are more restrictive.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
